### PR TITLE
Support for multiple decorators

### DIFF
--- a/transforms/ember-object/__testfixtures__/decorators.input.js
+++ b/transforms/ember-object/__testfixtures__/decorators.input.js
@@ -1,5 +1,5 @@
 import { alias, sum as add } from "@ember/object/computed";
-import { get, set, observer, computed } from "@ember/object";
+import { get, set, observer as watcher, computed } from "@ember/object";
 import { inject as controller } from "@ember/controller";
 import { inject as service } from "@ember/service";
 import { on } from "@ember/object/evented";
@@ -11,8 +11,12 @@ const Foo = EmberObject.extend({
   a: "",
   b: service("store"),
   myController: controller("abc"),
-  observedProp: observer("xyz"),
-  event: on("click"),
+  observedProp: watcher("xyz", function() {
+    return "observed";
+  }),
+  event: on("click", function() {
+    return "abc";
+  }),
 
   actions: {
     /**
@@ -28,7 +32,9 @@ const Foo = EmberObject.extend({
 
 var comp = EmberObject.extend({
   classNameBindings: ["isEnabled:enabled:disabled", "a:b:c", "c:d"],
-  isEnabled: false,
+  isEnabled: computed("a", "c", function() {
+    return false;
+  }),
   a: true,
   c: "",
   attributeBindings: ["customHref:href"],

--- a/transforms/ember-object/__testfixtures__/decorators.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators.output.js
@@ -1,8 +1,9 @@
-import { alias, sum as add } from "@ember/object/computed";
-import { get, set, observer, computed } from "@ember/object";
-import { inject as controller } from "@ember/controller";
-import { inject as service } from "@ember/service";
-import { on } from "@ember/object/evented";
+import { sum as add, alias } from "@ember-decorators/object/computed";
+import { get, set } from "@ember/object";
+import { computed, observes as watcher } from "@ember-decorators/object";
+import { controller as controller } from "@ember-decorators/controller";
+import { service as service } from "@ember-decorators/service";
+import { on } from "@ember-decorators/object/evented";
 import layout from "components/templates/foo";
 
 @tagName("div")
@@ -16,11 +17,15 @@ class Foo extends EmberObject {
   @controller("abc")
   myController;
 
-  @observes("xyz")
-  observedProp;
+  @watcher("xyz")
+  observedProp() {
+    return "observed";
+  }
 
   @on("click")
-  event;
+  event() {
+    return "abc";
+  }
 
   /**
   Comments
@@ -38,8 +43,11 @@ class Foo extends EmberObject {
 }
 
 class Comp extends EmberObject {
+  @computed("a", "c")
   @className("enabled", "disabled")
-  isEnabled = false;
+  get isEnabled() {
+    return false;
+  }
 
   @className("b", "c")
   a = true;
@@ -74,7 +82,7 @@ class Foo extends EmberObject {
   Computed description
   */
   @computed("fullName", "age", "country")
-  description() {
+  get description() {
     return `${this.get(
       "fullName"
     )}; Age: ${this.get("age")}; Country: ${this.get("country")}`;

--- a/transforms/ember-object/__testfixtures__/mixins.output.js
+++ b/transforms/ember-object/__testfixtures__/mixins.output.js
@@ -1,8 +1,9 @@
-import { alias, sum as add } from "@ember/object/computed";
-import { get, set, observer, computed } from "@ember/object";
-import { inject as controller } from "@ember/controller";
-import { inject as service } from "@ember/service";
-import { on } from "@ember/object/evented";
+import { sum as add, alias } from "@ember-decorators/object/computed";
+import { get, set } from "@ember/object";
+import { computed, observes } from "@ember-decorators/object";
+import { controller as controller } from "@ember-decorators/controller";
+import { service as service } from "@ember-decorators/service";
+import { on } from "@ember-decorators/object/evented";
 import layout from "components/templates/foo";
 import MixinA from "mixins/A";
 import MixinB from "mixins/B";
@@ -82,7 +83,7 @@ class Foo extends EmberObject.extend(MixinA, MixinB) {
   Computed description
   */
   @computed("fullName", "age", "country")
-  description() {
+  get description() {
     return `${this.get(
       "fullName"
     )}; Age: ${this.get("age")}; Country: ${this.get("country")}`;

--- a/transforms/helpers/EOProp.js
+++ b/transforms/helpers/EOProp.js
@@ -1,0 +1,99 @@
+const {
+  get,
+  getPropName,
+  getPropType,
+  getPropCalleeName,
+  isClassDecoratorProp,
+  METHOD_DECORATORS
+} = require("./util");
+
+/**
+ * Ember Objet Property
+ *
+ * A wrapper object for ember object properties
+ */
+class EOProp {
+  constructor(eoProp) {
+    this._prop = eoProp;
+    this.decoratorNames = [];
+  }
+
+  get value() {
+    return get(this._prop, "value");
+  }
+
+  get kind() {
+    let kind = get(this._prop, "kind");
+    if (kind === "init" && this.hasDecorators && !this.hasMethodDecorator) {
+      kind = "get";
+    }
+    return kind;
+  }
+
+  get key() {
+    return get(this._prop, "key");
+  }
+
+  get name() {
+    return getPropName(this._prop);
+  }
+
+  get type() {
+    return getPropType(this._prop);
+  }
+
+  get calleeName() {
+    return getPropCalleeName(this._prop);
+  }
+
+  get comments() {
+    return this._prop.comments;
+  }
+
+  get computed() {
+    return this._prop.computed;
+  }
+
+  get isClassDecorator() {
+    return isClassDecoratorProp(this.name);
+  }
+
+  get isCallExpression() {
+    return this.type === "CallExpression";
+  }
+
+  get hasDecorators() {
+    return this.decoratorNames.length;
+  }
+
+  get callExprArgs() {
+    return get(this._prop, "value.arguments") || [];
+  }
+
+  get hasNonLiteralArg() {
+    return this.callExprArgs.some(arg => arg.type !== "Literal");
+  }
+
+  setDecorators(importedDecoratedProps) {
+    if (this.isCallExpression) {
+      const { decoratorName, importedName } =
+        importedDecoratedProps[this.calleeName] || {};
+      if (decoratorName) {
+        this.hasMethodDecorator = METHOD_DECORATORS.includes(importedName);
+        this.decoratorNames.push(decoratorName);
+      }
+    }
+  }
+
+  addBindingProps(attributeBindingsProps, classNameBindingsProps) {
+    if (attributeBindingsProps[this.name]) {
+      this.decoratorNames.push("attribute");
+      this.propList = attributeBindingsProps[this.name];
+    } else if (classNameBindingsProps[this.name]) {
+      this.decoratorNames.push("className");
+      this.propList = classNameBindingsProps[this.name];
+    }
+  }
+}
+
+module.exports = EOProp;

--- a/transforms/helpers/parse-helper.js
+++ b/transforms/helpers/parse-helper.js
@@ -2,109 +2,67 @@ const path = require("path");
 const camelCase = require("camelcase");
 const {
   get,
-  getPropName,
-  getPropType,
-  getPropCalleeName,
   capitalizeFirstLetter,
-  isComputedProperty,
-  getComputedPropertyName,
   startsWithUpperCaseLetter,
-  DECORATOR_PROP_NAME
+  DECORATOR_PATHS
 } = require("./util");
-const { hasValidProps } = require("../helpers/validation-helper");
-const { withComments, createClass } = require("./transform-helper");
+const { hasValidProps } = require("./validation-helper");
+const {
+  withComments,
+  createClass,
+  createImportDeclaration
+} = require("./transform-helper");
+const EOProp = require("./EOProp");
 
 /**
  * Return the map of instance props and functions from Ember Object
  *
  * For example
- * const myObj = EmberObject.extend({ key: value, foo: function() {}, baz() {} });
+ * const myObj = EmberObject.extend({ key: value });
  * will be parsed as:
  * {
  *   instanceProps: [ Property({key: value}) ]
- *   functionProps: [ FunctionExpression(foo), FunctionExpression(baz) ]
- *   computedProps: [],
- *   classDecoratorProps: [],
  *  }
  * @param {Object} j - jscodeshift lib reference
  * @param {ObjectExpression} emberObjectExpression
  * @returns {Object} Object of instance and function properties
  */
-function getEmberObjectProperties(
-  j,
-  eoExpression,
-  importedComputedPropMacros = [],
-  importedDecoratedProps = {}
-) {
+function getEmberObjectProps(j, eoExpression, importedDecoratedProps = {}) {
   const objProps = get(eoExpression, "properties") || [];
 
   const instanceProps = [];
-  const functionProps = [];
-  const classDecoratorProps = [];
-  const computedProps = [];
   const attributeBindingsProps = {};
   const classNameBindingsProps = {};
 
-  objProps.forEach(prop => {
-    const propName = getPropName(prop);
-    if (propName === "classNameBindings") {
+  objProps.forEach(objProp => {
+    const prop = new EOProp(objProp);
+    if (prop.name === "classNameBindings") {
       Object.assign(
         classNameBindingsProps,
         parseBindingProps(prop.value.elements)
       );
-    } else if (propName === "attributeBindings") {
+    } else if (prop.name === "attributeBindings") {
       Object.assign(
         attributeBindingsProps,
         parseBindingProps(prop.value.elements)
       );
     } else {
-      if (isClassDecoratorProp(propName)) {
-        classDecoratorProps.push(prop);
-      } else if (getPropType(prop) === "FunctionExpression") {
-        functionProps.push(prop);
-      } else if (isComputedProperty(prop, importedComputedPropMacros)) {
-        prop.isComputed = true;
-        prop.decoratorName = getComputedPropertyName(prop);
-        computedProps.push(prop);
-      } else {
-        const calleeName = getPropCalleeName(prop);
-        if (calleeName) {
-          prop.decoratorName = importedDecoratedProps[calleeName];
-        }
-        instanceProps.push(prop);
-      }
+      prop.setDecorators(importedDecoratedProps);
+      instanceProps.push(prop);
     }
   });
 
   // Assign decoator names to the binding props if any
   instanceProps.forEach(instanceProp => {
-    const instancePropName = getPropName(instanceProp);
-    if (attributeBindingsProps[instancePropName]) {
-      instanceProp.decoratorName = "attribute";
-      instanceProp.propList = attributeBindingsProps[instancePropName];
-    } else if (classNameBindingsProps[instancePropName]) {
-      instanceProp.decoratorName = "className";
-      instanceProp.propList = classNameBindingsProps[instancePropName];
-    }
+    instanceProp.addBindingProps(
+      attributeBindingsProps,
+      classNameBindingsProps
+    );
   });
 
   return {
-    instanceProps,
-    computedProps,
-    functionProps,
-    classDecoratorProps
+    instanceProps
   };
-}
-
-/**
- * Return true if prop is of name `tagName` or `classNames`
- * @param {Property} prop
- * @returns boolean
- */
-function isClassDecoratorProp(propName) {
-  return (
-    propName === "tagName" || propName === "classNames" || propName === "layout"
-  );
 }
 
 /**
@@ -122,33 +80,131 @@ function isClassDecoratorProp(propName) {
  */
 function parseBindingProps(bindingPropElements = []) {
   return bindingPropElements.reduce((props, bindingElement) => {
-    const bindingElementList = bindingElement.value.split(":");
-    const boundPropName = bindingElementList.shift().trim();
-    props[boundPropName] = bindingElementList;
+    const [boundPropName, ...bindingElementList] = bindingElement.value.split(
+      ":"
+    );
+    props[boundPropName.trim()] = bindingElementList;
     return props;
   }, {});
 }
 
 /**
- * Get computed prop macros from `import` statements
+ * Return the decorator name for the specifier if any, using the importPropDecoratorMap from
+ * `DECORATOR_PATHS` config (defined util.js)
+ *
+ * @param {ImportSpecifier} specifier
+ * @param {Object} importPropDecoratorMap
+ * @returns {String}
+ */
+function getDecoratorInfo(specifier, importPropDecoratorMap) {
+  const localName = get(specifier, "local.name");
+  const importedName = get(specifier, "imported.name");
+  const isImportedAs = importedName !== localName;
+  let decoratorName;
+  if (isImportedAs || !importPropDecoratorMap) {
+    decoratorName = localName;
+  } else {
+    decoratorName = importPropDecoratorMap[importedName];
+  }
+  return { decoratorName, localName, importedName, isImportedAs };
+}
+
+/**
+ * Returns true of the specifier is a decorator
+ *
+ * @param {ImportSpecifier} specifier
+ * @param {Object} importPropDecoratorMap
+ * @returns {Boolean}
+ */
+function isSpecifierDecorator(specifier, importPropDecoratorMap) {
+  const importedName = get(specifier, "imported.name");
+  if (!importPropDecoratorMap || importPropDecoratorMap[importedName]) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Set decorator name and remove the duplicated `local` property on specifier
+ *
+ * @param {ImportSpecifier} specifier
+ * @param {Object} importPropDecoratorMap
+ * @returns {ImportSpecifier}
+ */
+function setSpecifierProps(specifier, importPropDecoratorMap) {
+  const importedName = get(specifier, "imported.name");
+  if (importPropDecoratorMap) {
+    specifier.imported.name = importPropDecoratorMap[importedName];
+  }
+  if (importedName === get(specifier, "local.name")) {
+    specifier.local = null;
+  }
+  return specifier;
+}
+
+/**
+ * Get decorated props from `import` statements
  *
  * @param {Object} j - jscodeshift lib reference
  * @param {File} root
- * @returns {String[]}
+ * @returns {ImportDeclaration[]}
  */
-function getImportedComputedPropMacros(j, root) {
-  const computedPropImports = root.find(j.ImportDeclaration, {
-    source: {
-      value: "@ember/object/computed"
+function getDecoratorImports(j, root) {
+  return Object.keys(DECORATOR_PATHS).reduce((imports, path) => {
+    const decoratorImports = root.find(j.ImportDeclaration, {
+      source: {
+        value: path
+      }
+    });
+
+    if (decoratorImports.length) {
+      imports.push(decoratorImports.get());
+    }
+
+    return imports;
+  }, []);
+}
+
+/**
+ * Get decorated props from `import` statements
+ *
+ * @param {Object} j - jscodeshift lib reference
+ * @param {File} root
+ * @returns {Object}
+ */
+function createDecoratorImportDeclarations(j, root) {
+  getDecoratorImports(j, root).forEach(decoratorImport => {
+    const { importPropDecoratorMap, decoratorPath } = DECORATOR_PATHS[
+      get(decoratorImport, "value.source.value")
+    ];
+
+    const decoratedSpecifiers = [];
+    const specifiers = get(decoratorImport, "value.specifiers") || [];
+
+    for (let i = specifiers.length - 1; i >= 0; i -= 1) {
+      const specifier = specifiers[i];
+
+      if (isSpecifierDecorator(specifier, importPropDecoratorMap)) {
+        decoratedSpecifiers.push(
+          setSpecifierProps(specifier, importPropDecoratorMap)
+        );
+        specifiers.splice(i, 1);
+      }
+    }
+    if (decoratedSpecifiers.length) {
+      const importDeclaration = createImportDeclaration(
+        j,
+        decoratedSpecifiers,
+        decoratorPath
+      );
+
+      if (specifiers.length <= 0) {
+        j(decoratorImport).replaceWith(importDeclaration);
+      } else {
+        j(decoratorImport).insertAfter(importDeclaration);
+      }
     }
   });
-
-  if (!computedPropImports.length) {
-    return [];
-  }
-
-  const cpImport = computedPropImports.get().value;
-  return cpImport.specifiers.map(specifier => get(specifier, "local.name"));
 }
 
 /**
@@ -159,34 +215,26 @@ function getImportedComputedPropMacros(j, root) {
  * @returns {Object}
  */
 function getImportedDecoratedProps(j, root) {
-  const importedDecorators = {};
-  const importedPaths = Object.keys(DECORATOR_PROP_NAME);
+  return getDecoratorImports(j, root).reduce(
+    (importedDecorators, decoratorImport) => {
+      const { importPropDecoratorMap } = DECORATOR_PATHS[
+        get(decoratorImport, "value.source.value")
+      ];
 
-  importedPaths.forEach(importedPath => {
-    const [imported, path] = importedPath.split(":");
-    const decorator = DECORATOR_PROP_NAME[importedPath];
-    const decoratorImports = root.find(j.ImportDeclaration, {
-      source: {
-        value: path
-      }
-    });
+      const specifiers = get(decoratorImport, "value.specifiers") || [];
 
-    if (!decoratorImports.length) {
-      return;
-    }
-
-    const decoratorImport = decoratorImports.get().value;
-
-    decoratorImport.specifiers.forEach(specifier => {
-      const decoratorLocalName = get(specifier, "local.name");
-      const decoratorImportedName = get(specifier, "imported.name");
-      if (imported === decoratorImportedName) {
-        importedDecorators[decoratorLocalName] = decorator;
-      }
-    });
-  });
-
-  return importedDecorators;
+      return specifiers.reduce((importedDecorators, specifier) => {
+        if (isSpecifierDecorator(specifier, importPropDecoratorMap)) {
+          importedDecorators[get(specifier, "local.name")] = getDecoratorInfo(
+            specifier,
+            importPropDecoratorMap
+          );
+        }
+        return importedDecorators;
+      }, importedDecorators);
+    },
+    {}
+  );
 }
 
 /**
@@ -298,8 +346,8 @@ function parseEmberObjectCallExpression(eoCallExpression) {
  */
 function replaceEmberObjectExpressions(j, root, filePath, options = {}) {
   // Parse the import statements
-  const importedComputedPropMacros = getImportedComputedPropMacros(j, root);
   const importedDecoratedProps = getImportedDecoratedProps(j, root);
+  let transformed = false;
 
   getEmberObjectCallExpressions(j, root).forEach(eoCallExpression => {
     const { eoExpression, mixins } = parseEmberObjectCallExpression(
@@ -309,14 +357,13 @@ function replaceEmberObjectExpressions(j, root, filePath, options = {}) {
       return;
     }
 
-    const eoProperties = getEmberObjectProperties(
+    const eoProps = getEmberObjectProps(
       j,
       eoExpression,
-      importedComputedPropMacros,
       importedDecoratedProps
     );
 
-    if (!hasValidProps(eoProperties, options.decorators)) {
+    if (!hasValidProps(eoProps, options.decorators)) {
       return;
     }
 
@@ -324,7 +371,7 @@ function replaceEmberObjectExpressions(j, root, filePath, options = {}) {
     const es6ClassDeclaration = createClass(
       j,
       getClassName(j, eoCallExpression, filePath),
-      eoProperties,
+      eoProps,
       superClassName,
       mixins
     );
@@ -333,15 +380,19 @@ function replaceEmberObjectExpressions(j, root, filePath, options = {}) {
     j(expressionToReplace).replaceWith(
       withComments(es6ClassDeclaration, expressionToReplace.value)
     );
+    transformed = true;
   });
+  // Need to find another way, as there might be a case where
+  // one object from a file is transformed and other is not
+  if (transformed) {
+    createDecoratorImportDeclarations(j, root);
+  }
 }
 
 module.exports = {
   getVariableName,
-  getEmberObjectProperties,
+  getEmberObjectProps,
   getEmberObjectCallExpressions,
-  getImportedComputedPropMacros,
-  getImportedDecoratedProps,
   getClosetVariableDeclaration,
   getExpressionToReplace,
   replaceEmberObjectExpressions,

--- a/transforms/helpers/validation-helper.js
+++ b/transforms/helpers/validation-helper.js
@@ -1,5 +1,3 @@
-const { get, getPropType } = require("./util");
-
 const UNSUPPORTED_PROP_NAMES = ["actions", "layout"];
 
 /**
@@ -9,25 +7,17 @@ const UNSUPPORTED_PROP_NAMES = ["actions", "layout"];
  * @param {Boolean} useDecorator
  * @returns Boolean
  */
-function hasValidProps(
-  { instanceProps = [], computedProps = [], classDecoratorProps = [] } = {},
-  useDecorator = false
-) {
-  if (!useDecorator && (computedProps.length || classDecoratorProps.length)) {
-    return false;
-  }
-
+function hasValidProps({ instanceProps = [] } = {}, useDecorator = false) {
   const unsupportedPropNames = useDecorator ? [] : UNSUPPORTED_PROP_NAMES;
 
   return instanceProps.every(instanceProp => {
-    const propName = get(instanceProp, "key.name");
-    const propType = getPropType(instanceProp);
-
     if (
-      (!useDecorator && instanceProp.decoratorName) ||
-      unsupportedPropNames.includes(propName) ||
-      (propType === "ObjectExpression" && propName !== "actions") ||
-      (propType === "CallExpression" && !instanceProp.decoratorName)
+      (!useDecorator &&
+        (instanceProp.hasDecorators || instanceProp.isClassDecorator)) ||
+      unsupportedPropNames.includes(instanceProp.name) ||
+      (instanceProp.type === "ObjectExpression" &&
+        instanceProp.name !== "actions") ||
+      (instanceProp.isCallExpression && !instanceProp.hasDecorators)
     ) {
       return false;
     }


### PR DESCRIPTION
- Support for multiple decorators
- Handle the different decorator corner cases
- Replace the imports with appropriate paths from `ember-decorators`

Introduced a new class EOProp.js, a wrapper for `EmberObjectProperty` to avoid mutating the `ClassProperty` object returned from jscodeshift parser