### PR TITLE
Fix bug of having duplicate local specifier name

### DIFF
--- a/transforms/ember-object/__testfixtures__/decorators.output.js
+++ b/transforms/ember-object/__testfixtures__/decorators.output.js
@@ -1,8 +1,8 @@
 import { sum as add, alias } from "@ember-decorators/object/computed";
 import { get, set } from "@ember/object";
 import { computed, observes as watcher } from "@ember-decorators/object";
-import { controller as controller } from "@ember-decorators/controller";
-import { service as service } from "@ember-decorators/service";
+import { controller } from "@ember-decorators/controller";
+import { service } from "@ember-decorators/service";
 import { on } from "@ember-decorators/object/evented";
 import layout from "components/templates/foo";
 

--- a/transforms/helpers/parse-helper.js
+++ b/transforms/helpers/parse-helper.js
@@ -133,12 +133,16 @@ function isSpecifierDecorator(specifier, importPropDecoratorMap) {
  * @returns {ImportSpecifier}
  */
 function setSpecifierProps(specifier, importPropDecoratorMap) {
-  const importedName = get(specifier, "imported.name");
-  if (importPropDecoratorMap) {
-    specifier.imported.name = importPropDecoratorMap[importedName];
-  }
-  if (importedName === get(specifier, "local.name")) {
-    specifier.local = null;
+  const decoratorImportedName = get(
+    importPropDecoratorMap,
+    get(specifier, "imported.name")
+  );
+  if (decoratorImportedName) {
+    specifier.imported.name = decoratorImportedName;
+
+    if (decoratorImportedName === get(specifier, "local.name")) {
+      specifier.local = null;
+    }
   }
   return specifier;
 }


### PR DESCRIPTION
Example:
This will fix
`import { controller as controller } from "@ember-decorators/controller";`
to
`import { controller } from "@ember-decorators/controller";`