### PR TITLE
Append the object type by default to the transformed class

### DIFF
--- a/transforms/helpers/parse-helper.js
+++ b/transforms/helpers/parse-helper.js
@@ -470,14 +470,16 @@ function getClassName(
   eoCallExpression,
   filePath,
   superClassName,
-  type = "EmberObject"
+  type = ""
 ) {
   const varDeclaration = getClosetVariableDeclaration(j, eoCallExpression);
   const className =
     getVariableName(varDeclaration) || camelCase(path.basename(filePath, "js"));
-  let capitalizedClassName = capitalizeFirstLetter(className);
+  let capitalizedClassName = `${capitalizeFirstLetter(
+    className
+  )}${capitalizeFirstLetter(type)}`;
   if (capitalizedClassName === superClassName) {
-    capitalizedClassName += capitalizeFirstLetter(type);
+    capitalizedClassName = capitalizeFirstLetter(className);
   }
   return capitalizedClassName;
 }


### PR DESCRIPTION
In earlier implementation type would be appended to the class only in case of name collision between class name and super class. With this PR we're appending the type to class name by default, in case of collision the type would be dropped